### PR TITLE
Add combined tickets/comments importer and fix timestamp for initial issue

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,7 @@ from syncro_config_object import SyncroConfig
 from syncro_configs import setup_logging, get_logger, TEMP_FILE_PATH, SYNCRO_API_KEY, SYNCRO_SUBDOMAIN
 from main_tickets import run_tickets
 from main_comments import run_comments
+from main_tickets_comments_combined import run_tickets_comments_combined
 import logging
 
 logger = get_logger(__name__)
@@ -85,14 +86,17 @@ def main_menu():
     print("Choose your importer:")
     print("1. Tickets")
     print("2. Comments")
-    choice = input("Enter 1 or 2: ").strip()
+    print("3. Tickets and Comments Combined")
+    choice = input("Enter 1, 2 or 3: ").strip()
 
     if choice == "1":
         run_tickets(config)
     elif choice == "2":
         run_comments(config)
+    elif choice == "3":
+        run_tickets_comments_combined(config)
     else:
-        print("Invalid selection. Please enter 1 or 2.")
+        print("Invalid selection. Please enter 1, 2 or 3.")
 
 
 if __name__ == "__main__":

--- a/main_tickets_comments_combined.py
+++ b/main_tickets_comments_combined.py
@@ -14,43 +14,38 @@ from syncro_write import (
 from syncro_read import get_syncro_ticket_by_number
 from syncro_configs import get_logger
 
-def main():
-    logger = get_logger("main")    
-    tickets = syncro_get_all_tickets_and_comments_from_combined_csv()
-    
-    tickets_in_order = order_ticket_rows_by_date(tickets)
-    logger.info(f"Tickets in order type: {type(tickets_in_order)}")
-    for key, value in tickets_in_order.items():
-        logger.info(f"Key: {key}, Value Type: {type(value)}")
-        
-        ticket_number= key
-        check_for_existing_tickets = get_syncro_ticket_by_number(ticket_number)     
-        
-        if check_for_existing_tickets:
+
+logger = get_logger(__name__)
+
+
+def run_tickets_comments_combined(config):
+    try:
+        tickets = syncro_get_all_tickets_and_comments_from_combined_csv()
+        tickets_in_order = order_ticket_rows_by_date(tickets)
+    except Exception as e:
+        logger.critical(f"Failed to load combined tickets and comments: {e}")
+        return
+
+    for ticket_number, entries in tickets_in_order.items():
+        existing_ticket = get_syncro_ticket_by_number(config, ticket_number)
+
+        if existing_ticket:
             logger.info(f"Ticket {ticket_number} does exist, passing")
-            logger.info(f"check_for_existing_tickets: {check_for_existing_tickets}")
             continue
-        else:
-            logger.info(f"Ticket {ticket_number} does not exist, creating ticket")    
-            logger.info(f'Data for ticket values is : {value}')
-            
-            for index, (timestamp, ticket_data) in enumerate(value):
-                      
-                if index == 0:
-                    json_payload = syncro_prepare_ticket_combined_json(ticket_data)  
-                    print(f"Creating new ticket: {ticket_number}")
-                    response = syncro_create_ticket(json_payload)
-                else:
-                    print(f"Adding comment to ticket: {ticket_number}")
-                    json_payload = syncro_prepare_ticket_combined_comment_json(ticket_data)  
-                    response = syncro_create_comment(json_payload)
 
-                    if response:
-                        print(f"Successfully created comment: {ticket_number}")
-                    else:
-                        print(f"Failed Comment: {ticket_number}")
+        logger.info(f"Ticket {ticket_number} does not exist, creating ticket")
+        for index, (timestamp, ticket_data) in enumerate(entries):
+            if index == 0:
+                json_payload = syncro_prepare_ticket_combined_json(config, ticket_data)
+                logger.info(f"Creating new ticket: {ticket_number}")
+                syncro_create_ticket(config, json_payload)
+            else:
+                json_payload = syncro_prepare_ticket_combined_comment_json(ticket_data)
+                logger.info(f"Adding comment to ticket: {ticket_number}")
+                syncro_create_comment(config, json_payload)
 
-            logger.info(f"Completed Ticket {ticket_number}")  
+        logger.info(f"Completed Ticket {ticket_number}")
+
 
 if __name__ == "__main__":
-    main()
+    print("This is main_tickets_comments_combined.py")


### PR DESCRIPTION
## Summary
- Support importing combined tickets and comments through CLI
- Ensure initial ticket issue uses original creation timestamp

## Testing
- `python -m py_compile cli.py main_tickets_comments_combined.py syncro_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_689a128213d88321b0a968eeee7c75c6