### PR TITLE
Prompt to use default issue type when validation fails

### DIFF
--- a/csv_utils.py
+++ b/csv_utils.py
@@ -197,9 +197,25 @@ def validate_ticket_data(
             logger.error(
                 f"Row {row_num}: Issue type '{issue_type_val}' not found in API cache."
             )
-            raise ValueError(
-                f"Row {row_num}: Issue type '{issue_type_val}' not found in API cache."
-            )
+            default_issue_type = DEFAULTS.get("ticket issue type")
+            if default_issue_type and default_issue_type.lower() in issue_type_names:
+                response = input(
+                    f"Row {row_num}: Issue type '{issue_type_val}' not found. "
+                    f"Use default '{default_issue_type}' instead? (y/N): "
+                ).strip().lower()
+                if response == "y":
+                    ticket["ticket issue type"] = default_issue_type
+                    logger.info(
+                        f"Row {row_num}: Issue type set to default '{default_issue_type}'."
+                    )
+                else:
+                    raise ValueError(
+                        f"Row {row_num}: Issue type '{issue_type_val}' not found in API cache."
+                    )
+            else:
+                raise ValueError(
+                    f"Row {row_num}: Issue type '{issue_type_val}' not found in API cache."
+                )
 
         if status_val not in status_names:
             logger.warning("Status names cannot be normalized. Must be perfect match")

--- a/main_tickets.py
+++ b/main_tickets.py
@@ -8,10 +8,11 @@ from syncro_configs import get_logger
 logger = get_logger(__name__)
 def run_tickets(config):
     try:
-        tickets = syncro_get_all_tickets_from_csv(config)        
+        tickets = syncro_get_all_tickets_from_csv(config)
         logger.info(f"Loaded tickets: {len(tickets)}")
     except Exception as e:
         logger.critical(f"Failed to load tickets: {e}")
+        return
 
     for ticket in tickets:
         ticket_json = syncro_prepare_ticket_json(config,ticket)


### PR DESCRIPTION
## Summary
- ask user to apply default issue type when an unknown issue type is detected during CSV validation
- stop ticket import when loading tickets fails to prevent undefined variable errors

## Testing
- `python -m py_compile csv_utils.py main_tickets.py`


------
https://chatgpt.com/codex/tasks/task_e_689cde0b77dc8321b7d68c082cf276a7