### PR TITLE
Prompt to use default issue type when validation fails

### DIFF
--- a/main_tickets.py
+++ b/main_tickets.py
@@ -8,10 +8,11 @@ from syncro_configs import get_logger
 logger = get_logger(__name__)
 def run_tickets(config):
     try:
-        tickets = syncro_get_all_tickets_from_csv(config)        
+        tickets = syncro_get_all_tickets_from_csv(config)
         logger.info(f"Loaded tickets: {len(tickets)}")
     except Exception as e:
         logger.critical(f"Failed to load tickets: {e}")
+        return
 
     for ticket in tickets:
         ticket_json = syncro_prepare_ticket_json(config,ticket)


### PR DESCRIPTION
## Summary
- ask user once to apply default issue type for all unknown issue types during CSV validation
- stop ticket import when loading tickets fails to prevent undefined variable errors

## Testing
- `python -m py_compile csv_utils.py main_tickets.py`


------
https://chatgpt.com/codex/tasks/task_e_689cde0b77dc8321b7d68c082cf276a7