### PR TITLE
Add automated timer entry generation for recent tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Importer doesnt account for:
    - Run `cli.py` to load in the tickets or comments.  
    - You will be prompted to choose logging level, Clear Temp_Data, Enter Subdomain and API Key
    - Last will ask you to pick either Ticket or Comments to import.
+   - Option 4 will generate timer entries for the most recent 25 tickets using your techs and labor products.
    - Data is validated on csv load and will error out of the import without the csv being filled out
 
 

--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ from syncro_configs import setup_logging, get_logger, TEMP_FILE_PATH, SYNCRO_API
 from main_tickets import run_tickets
 from main_comments import run_comments
 from main_tickets_comments_combined import run_tickets_comments_combined
+from main_timer_entries import run_timer_entries
 import logging
 
 logger = get_logger(__name__)
@@ -87,7 +88,8 @@ def main_menu():
     print("1. Tickets")
     print("2. Comments")
     print("3. Tickets and Comments Combined")
-    choice = input("Enter 1, 2 or 3: ").strip()
+    print("4. Generate Timer Entries")
+    choice = input("Enter 1, 2, 3 or 4: ").strip()
 
     if choice == "1":
         run_tickets(config)
@@ -95,8 +97,10 @@ def main_menu():
         run_comments(config)
     elif choice == "3":
         run_tickets_comments_combined(config)
+    elif choice == "4":
+        run_timer_entries(config)
     else:
-        print("Invalid selection. Please enter 1, 2 or 3.")
+        print("Invalid selection. Please enter 1, 2, 3 or 4.")
 
 
 if __name__ == "__main__":

--- a/main_timer_entries.py
+++ b/main_timer_entries.py
@@ -1,0 +1,215 @@
+"""Generate realistic Syncro timer entries for the most recent tickets."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from datetime import datetime, time, timedelta, tzinfo
+from typing import Dict, List
+
+import pytz
+from dateutil import parser
+
+from syncro_configs import SYNCRO_TIMEZONE, get_logger
+from syncro_read import (
+    syncro_get_all_techs,
+    syncro_get_labor_products,
+    syncro_get_recent_tickets,
+)
+from syncro_write import syncro_create_time_entry
+
+logger = get_logger(__name__)
+
+WORKDAY_START_HOUR = 7
+WORKDAY_END_HOUR = 18
+WORKDAY_MINUTES = (WORKDAY_END_HOUR - WORKDAY_START_HOUR) * 60
+MIN_UTILIZATION = 0.30
+MAX_UTILIZATION = 0.80
+MIN_ENTRY_MINUTES = 15
+MAX_ENTRY_MINUTES = 240
+
+
+def _normalize_datetime(value: str, tz: tzinfo) -> datetime:
+    """Parse a string datetime and convert it to the configured timezone."""
+    try:
+        dt = parser.parse(value)
+    except (TypeError, ValueError) as exc:
+        logger.warning(f"Unable to parse datetime '{value}': {exc}. Using current time instead.")
+        dt = datetime.now(tz)
+
+    if dt.tzinfo is None:
+        dt = tz.localize(dt)
+    else:
+        dt = dt.astimezone(tz)
+    return dt
+
+
+def _build_note(ticket: Dict) -> str:
+    """Create a friendly note for the time entry based on ticket metadata."""
+    subject = (
+        ticket.get("subject")
+        or ticket.get("summary")
+        or ticket.get("problem_type")
+        or ticket.get("issue_type")
+        or "General work"
+    )
+    number = ticket.get("number") or ticket.get("id")
+    return f"Worked on ticket {number}: {subject}"
+
+
+def _generate_durations(entry_count: int) -> List[int]:
+    """Generate durations that satisfy utilization constraints."""
+    if entry_count == 0:
+        return []
+
+    min_total = max(int(WORKDAY_MINUTES * MIN_UTILIZATION), entry_count * MIN_ENTRY_MINUTES)
+    max_total = min(int(WORKDAY_MINUTES * MAX_UTILIZATION), entry_count * MAX_ENTRY_MINUTES)
+
+    if min_total > max_total:
+        # If there are many tickets, fall back to filling most of the day.
+        min_total = max_total
+
+    target_total = random.randint(min_total, max_total)
+
+    remaining = target_total
+    durations: List[int] = []
+
+    for idx in range(entry_count):
+        entries_left = entry_count - idx
+        if entries_left == 1:
+            duration = remaining
+        else:
+            max_for_entry = remaining - MIN_ENTRY_MINUTES * (entries_left - 1)
+            min_for_entry = MIN_ENTRY_MINUTES
+            if max_for_entry <= min_for_entry:
+                duration = min_for_entry
+            else:
+                duration = random.randint(min_for_entry, max_for_entry)
+        durations.append(duration)
+        remaining -= duration
+
+    return durations
+
+
+def _generate_time_entries_for_day(date_key, assignments, labor_products, tz):
+    """Generate timer entries for a single date keyed by tech."""
+    generated_entries = []
+    workday_start = tz.localize(datetime.combine(date_key, time(hour=WORKDAY_START_HOUR)))
+
+    for tech_id, tickets in assignments.items():
+        if not tickets:
+            continue
+
+        durations = _generate_durations(len(tickets))
+        total_minutes = sum(durations)
+        available_offset = WORKDAY_MINUTES - total_minutes
+        start_offset = random.randint(0, available_offset) if available_offset > 0 else 0
+        current_offset = start_offset
+
+        sorted_tickets = sorted(tickets, key=lambda item: item["created_at"])
+
+        for duration, assignment in zip(durations, sorted_tickets):
+            ticket = assignment["ticket"]
+            tech = assignment["tech"]
+            labor_product = random.choice(labor_products)
+
+            start_time = workday_start + timedelta(minutes=current_offset)
+            end_time = start_time + timedelta(minutes=duration)
+            current_offset += duration
+
+            generated_entries.append(
+                {
+                    "ticket_id": ticket.get("id"),
+                    "time_entry": {
+                        "user_id": tech.get("id"),
+                        "labor_product_id": labor_product.get("id"),
+                        "minutes": duration,
+                        "started_at": start_time.isoformat(),
+                        "ended_at": end_time.isoformat(),
+                        "notes": _build_note(ticket),
+                    },
+                }
+            )
+
+    return generated_entries
+
+
+def build_timer_entries(config) -> List[Dict]:
+    tz = pytz.timezone(SYNCRO_TIMEZONE)
+
+    tickets = syncro_get_recent_tickets(config)
+    if not tickets:
+        logger.warning("No recent tickets retrieved. Aborting timer entry creation.")
+        return []
+
+    techs = [
+        tech
+        for tech in syncro_get_all_techs(config)
+        if tech.get("id") and not tech.get("disabled", False)
+    ]
+    if not techs:
+        logger.error("No techs available to assign timer entries.")
+        return []
+
+    labor_products = [
+        product
+        for product in syncro_get_labor_products(config)
+        if product.get("id") and not product.get("archived", False)
+    ]
+    if not labor_products:
+        logger.error("No labor products found. Unable to create timer entries.")
+        return []
+
+    assignments = defaultdict(lambda: defaultdict(list))
+
+    for ticket in tickets:
+        created_at_raw = ticket.get("created_at")
+        created_at = _normalize_datetime(created_at_raw, tz) if created_at_raw else datetime.now(tz)
+        date_key = created_at.date()
+        tech = random.choice(techs)
+        assignments[date_key][tech.get("id")].append(
+            {
+                "ticket": ticket,
+                "tech": tech,
+                "created_at": created_at,
+            }
+        )
+
+    generated_entries = []
+    for date_key, tech_assignments in assignments.items():
+        generated_entries.extend(_generate_time_entries_for_day(date_key, tech_assignments, labor_products, tz))
+
+    return generated_entries
+
+
+def run_timer_entries(config) -> None:
+    """Generate and push Syncro timer entries for the latest tickets."""
+
+    logger.info("Starting timer entry generation workflow.")
+    entries = build_timer_entries(config)
+
+    if not entries:
+        logger.warning("No timer entries were generated.")
+        return
+
+    success_count = 0
+    for entry in entries:
+        ticket_id = entry["ticket_id"]
+        payload = entry["time_entry"]
+
+        if not ticket_id:
+            logger.warning("Skipping timer entry with missing ticket ID: %s", payload)
+            continue
+
+        if not payload.get("user_id") or not payload.get("labor_product_id"):
+            logger.warning("Skipping timer entry missing required associations: %s", payload)
+            continue
+
+        response = syncro_create_time_entry(config, ticket_id, payload)
+        if response:
+            success_count += 1
+
+    logger.info("Completed timer entry generation. %s entries created successfully.", success_count)
+
+
+__all__ = ["run_timer_entries", "build_timer_entries"]

--- a/syncro_read.py
+++ b/syncro_read.py
@@ -1,4 +1,6 @@
 import time
+from typing import List
+
 import requests
 
 # Import from syncro_config and utils
@@ -126,7 +128,7 @@ def syncro_get_all_contacts(config):
  
 def syncro_get_all_tickets(config):
     endpoint = '/tickets'
-    try:        
+    try:
         tickets = syncro_api_call_paginated(config, endpoint)
         logger.debug(f"Retrieved {len(tickets)} tickets: {tickets}")
         return tickets
@@ -134,16 +136,50 @@ def syncro_get_all_tickets(config):
         logger.error(f"Error fetching tickets: {e}")
         return []
 
+
+def syncro_get_recent_tickets(config, limit: int = 25) -> List[dict]:
+    """Fetch the most recent Syncro tickets up to the provided limit."""
+    endpoint = '/tickets'
+    params = {
+        "page": 1,
+        "per_page": limit,
+        "sort": "created_at",
+        "order": "desc",
+    }
+
+    try:
+        response = syncro_api_call(config, "GET", endpoint, params=params)
+        tickets = response.get("tickets", []) if response else []
+        logger.info(f"Fetched {len(tickets)} recent tickets")
+        return tickets[:limit]
+    except Exception as exc:
+        logger.error(f"Error fetching recent tickets: {exc}")
+        return []
+
 def syncro_get_all_techs(config):
     """Fetch all techs (users) from SyncroMSP API."""
     endpoint = '/users'
-    try:   
-        techs = syncro_api_call_paginated(config, endpoint)      
-        logger.debug(f"Retrieved {len(techs)} techs: {techs}")        
+    try:
+        techs = syncro_api_call_paginated(config, endpoint)
+        logger.debug(f"Retrieved {len(techs)} techs: {techs}")
         return techs
 
     except Exception as e:
         logger.error(f"Error fetching techs: {e}")
+        return []
+
+
+def syncro_get_labor_products(config) -> List[dict]:
+    """Retrieve all labor products that can be used for timer entries."""
+    endpoint = '/products'
+    params = {"type": "labor"}
+
+    try:
+        products = syncro_api_call_paginated(config, endpoint, params=params)
+        logger.info(f"Retrieved {len(products)} labor products")
+        return products
+    except Exception as exc:
+        logger.error(f"Error fetching labor products: {exc}")
         return []
 
 def syncro_get_ticket_data(config, ticket_id: int):

--- a/syncro_write.py
+++ b/syncro_write.py
@@ -210,7 +210,7 @@ def syncro_create_comment(config,comment_data: dict) -> dict:
         else:
             logger.error(f"Failed to create ticket. Response: {response}")
             return None
-        
+
     except requests.exceptions.HTTPError as http_err:
         # Log HTTP error details
         logger.error(f"HTTP error occurred: {http_err}")
@@ -222,6 +222,30 @@ def syncro_create_comment(config,comment_data: dict) -> dict:
         # Log unexpected errors
         logger.error(f"Unexpected error occurred while creating ticket: {e}")
         return None
+
+
+def syncro_create_time_entry(config, ticket_id: int, time_entry_data: dict) -> dict:
+    """Create a time entry on a ticket."""
+
+    endpoint = f"/tickets/{ticket_id}/time_entries"
+    payload = {"time_entry": time_entry_data}
+
+    try:
+        response = syncro_api_call(config, "POST", endpoint, data=payload)
+        if response:
+            logger.info(
+                "Created time entry on ticket %s for user %s (%s minutes)",
+                ticket_id,
+                time_entry_data.get("user_id"),
+                time_entry_data.get("minutes"),
+            )
+        else:
+            logger.error("Failed to create time entry for ticket %s", ticket_id)
+        return response
+    except Exception as exc:
+        logger.error(f"Error creating time entry for ticket {ticket_id}: {exc}")
+        return None
+
 
 if __name__ == "__main__":
     print("This module is not intended to be run directly.")


### PR DESCRIPTION
## Summary
- add a CLI option to generate timer entries for the latest 25 Syncro tickets
- implement a timer entry generator that assigns realistic schedules across techs and labor products
- extend Syncro API helpers to retrieve recent tickets, labor products, and create time entries

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68df0c9f0cdc83219b2672ef050ab051